### PR TITLE
Make archive output dir optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Optional archive output directory
+option(SCALATRIX_SET_ARCHIVE_OUTPUT_DIR "Set custom archive output directory" OFF)
+if(SCALATRIX_SET_ARCHIVE_OUTPUT_DIR)
+    set(SCALATRIX_ARCHIVE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/build/native" CACHE PATH "Archive output directory")
+endif()
+
 set(Eigen3_DIR "/opt/homebrew/Cellar/eigen/3.4.0_1/share/eigen3/cmake")
 find_package(Eigen3 REQUIRED)
 
@@ -54,11 +60,15 @@ set(SOURCES
 # endif()
 
 add_library(scalatrix STATIC ${SOURCES})
-    target_include_directories(scalatrix PUBLIC include)
-    target_link_libraries(scalatrix PRIVATE Eigen3::Eigen)
+target_include_directories(scalatrix PUBLIC include)
+target_link_libraries(scalatrix PRIVATE Eigen3::Eigen)
+
+# Optionally set archive output directory
+if(SCALATRIX_SET_ARCHIVE_OUTPUT_DIR)
     set_target_properties(scalatrix PROPERTIES
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build/native
-)
+        ARCHIVE_OUTPUT_DIRECTORY ${SCALATRIX_ARCHIVE_OUTPUT_DIR}
+    )
+endif()
 
 if (EMSCRIPTEN)
     add_executable(scalatrix_wasm ${SOURCES})


### PR DESCRIPTION
Make build archive output directory optional

  This PR addresses issue #1 by making the hardcoded archive output directory configurable and optional by default.

  ### Problem

  Previously, the scalatrix target had a hardcoded ARCHIVE_OUTPUT_DIRECTORY set to ${CMAKE_SOURCE_DIR}/build/native.
   This caused issues when consuming the library as a dependency, as it would force artifacts into the consumer's
  source tree.

  ### Solution

  The archive output directory is now optional and configurable through CMake options:

  - Default behavior: No archive output directory is specified, allowing CMake to use its default build locations
  - Backwards compatibility: Projects can enable the previous behavior by setting
  -DSCALATRIX_SET_ARCHIVE_OUTPUT_DIR=ON (this will use ${CMAKE_SOURCE_DIR}/build/native as before)
  - Customization: The output path can be customized with -DSCALATRIX_ARCHIVE_OUTPUT_DIR=/custom/path

  ### Changes

  1. Added SCALATRIX_SET_ARCHIVE_OUTPUT_DIR option (defaults to OFF)
  2. Added SCALATRIX_ARCHIVE_OUTPUT_DIR cache variable (defaults to ${CMAKE_SOURCE_DIR}/build/native when enabled)
  3. Wrapped the ARCHIVE_OUTPUT_DIRECTORY property in a conditional block
  4. Fixed indentation for constistency

  ### Usage Examples

  Default usage (recommended for library consumers):
```
  cmake -B build -S .
  # Archive outputs to CMake's default location (typically build/libscalatrix.a)
```


  Enable previous behavior (maintains backwards compatibility):
```
  cmake -B build -S . -DSCALATRIX_SET_ARCHIVE_OUTPUT_DIR=ON
  # Archive outputs to ${CMAKE_SOURCE_DIR}/build/native/libscalatrix.a
```

  Custom output directory:
```
  cmake -B build -S . -DSCALATRIX_SET_ARCHIVE_OUTPUT_DIR=ON -DSCALATRIX_ARCHIVE_OUTPUT_DIR=/my/custom/path
  # Archive outputs to /my/custom/path/libscalatrix.a
```
  ### Testing

  - Tested default configuration (no archive output directory set)
  - Tested with SCALATRIX_SET_ARCHIVE_OUTPUT_DIR=ON to verify it uses ${CMAKE_SOURCE_DIR}/build/native
  - Verified CMake cache variables are properly set
